### PR TITLE
docs(readme): ensure 4pda link accessibility and secure connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
   </tr>
   <tr>
     <td colspan="2" align="center">
-      http://4pda.ru/forum/index.php?showtopic=643084
+      https://4pda.to/forum/index.php?showtopic=643084
     </td>
   </tr>
   <tr>
@@ -82,7 +82,7 @@
   </tr>
   <tr>
     <td colspan="2" align="center">
-      http://www.temblast.com/ref/loaders.htm
+      https://www.temblast.com/ref/loaders.htm
     </td>
   </tr>
 </tfoot>


### PR DESCRIPTION
* Access to [4pda.**ru**](https://4pda.ru) in Russia blocked by RKN since 2021 ([Блокировка 4pda.ru](https://4pda.to/forum/index.php?showtopic=1024777)). Now the most relevant domain zone is .**to**, which is also used by all search engines;
* Tell the browser to use https for all presented links.